### PR TITLE
Allow having zero favourite rows

### DIFF
--- a/delicolour/main.py
+++ b/delicolour/main.py
@@ -49,8 +49,8 @@ def _parse_args():
         _perror('--fav-colours-count must be in [1, 16] range')
 
     # validate --fav-colours-rows-count
-    if args.fav_colours_rows_count < 1 or args.fav_colours_rows_count > 4:
-        _perror('--fav-colours-rows-count must be in [1, 4] range')
+    if args.fav_colours_rows_count < 0 or args.fav_colours_rows_count > 4:
+        _perror('--fav-colours-rows-count must be in [0, 4] range')
 
     # validate --increment
     mn = config.INCR_SPINNER_MIN_VAL


### PR DESCRIPTION
I've tested this and there doesn't seem to be a reason why you can't set `--fav-colours-rows-count`, other than the validation.